### PR TITLE
Order handler with nested user route (#81)

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -367,7 +367,203 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/orders/{order_id}/payments": {
+        "/api/order": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "order"
+                ],
+                "summary": "Save the order",
+                "parameters": [
+                    {
+                        "description": "Provide order object",
+                        "name": "order",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/order.Order"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/order.Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/order/statuses": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "order"
+                ],
+                "summary": "Get list of order statuses",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/order.OrderStatus"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/order/{id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "order"
+                ],
+                "summary": "Get the order",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order Id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/order.Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "order"
+                ],
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Hard delete",
+                        "name": "hard",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/order/{id}/status": {
+            "patch": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "order"
+                ],
+                "summary": "update order status",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Provide order status object",
+                        "name": "order_status",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/order.OrderStatus"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/orders/{id}/payments": {
             "get": {
                 "produces": [
                     "application/json"
@@ -379,8 +575,8 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "Payment Id",
-                        "name": "order_id",
+                        "description": "order Id",
+                        "name": "id",
                         "in": "path",
                         "required": true
                     }
@@ -1167,6 +1363,49 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/user/{user_id}/order": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "order"
+                ],
+                "summary": "Get orders by user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User Id",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/order.Order"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/users/{user_id}/addresses": {
             "get": {
                 "produces": [
@@ -1278,6 +1517,66 @@ const docTemplate = `{
                 },
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "order.Order": {
+            "type": "object",
+            "properties": {
+                "billing_state": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "order_items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/orderitem.OrderItem"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                },
+                "sub_total_amount": {
+                    "type": "number"
+                },
+                "tax_amount": {
+                    "type": "number"
+                },
+                "total_amount": {
+                    "type": "number"
+                },
+                "user_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "order.OrderStatus": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "orderitem.OrderItem": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "order_id": {
+                    "type": "integer"
+                },
+                "product_id": {
+                    "type": "integer"
+                },
+                "quantity": {
+                    "type": "integer"
+                },
+                "unit_price": {
+                    "type": "number"
                 }
             }
         },

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -356,7 +356,203 @@
                 }
             }
         },
-        "/api/orders/{order_id}/payments": {
+        "/api/order": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "order"
+                ],
+                "summary": "Save the order",
+                "parameters": [
+                    {
+                        "description": "Provide order object",
+                        "name": "order",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/order.Order"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/order.Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/order/statuses": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "order"
+                ],
+                "summary": "Get list of order statuses",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/order.OrderStatus"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/order/{id}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "order"
+                ],
+                "summary": "Get the order",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order Id",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/order.Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "order"
+                ],
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Hard delete",
+                        "name": "hard",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/order/{id}/status": {
+            "patch": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "order"
+                ],
+                "summary": "update order status",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Provide order status object",
+                        "name": "order_status",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/order.OrderStatus"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/orders/{id}/payments": {
             "get": {
                 "produces": [
                     "application/json"
@@ -368,8 +564,8 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "Payment Id",
-                        "name": "order_id",
+                        "description": "order Id",
+                        "name": "id",
                         "in": "path",
                         "required": true
                     }
@@ -1156,6 +1352,49 @@
                 }
             }
         },
+        "/api/user/{user_id}/order": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "order"
+                ],
+                "summary": "Get orders by user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User Id",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/order.Order"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errdto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/users/{user_id}/addresses": {
             "get": {
                 "produces": [
@@ -1267,6 +1506,66 @@
                 },
                 "message": {
                     "type": "string"
+                }
+            }
+        },
+        "order.Order": {
+            "type": "object",
+            "properties": {
+                "billing_state": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "order_items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/orderitem.OrderItem"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                },
+                "sub_total_amount": {
+                    "type": "number"
+                },
+                "tax_amount": {
+                    "type": "number"
+                },
+                "total_amount": {
+                    "type": "number"
+                },
+                "user_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "order.OrderStatus": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "orderitem.OrderItem": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "order_id": {
+                    "type": "integer"
+                },
+                "product_id": {
+                    "type": "integer"
+                },
+                "quantity": {
+                    "type": "integer"
+                },
+                "unit_price": {
+                    "type": "number"
                 }
             }
         },

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -40,6 +40,45 @@ definitions:
       message:
         type: string
     type: object
+  order.Order:
+    properties:
+      billing_state:
+        type: string
+      id:
+        type: integer
+      order_items:
+        items:
+          $ref: '#/definitions/orderitem.OrderItem'
+        type: array
+      status:
+        type: string
+      sub_total_amount:
+        type: number
+      tax_amount:
+        type: number
+      total_amount:
+        type: number
+      user_id:
+        type: integer
+    type: object
+  order.OrderStatus:
+    properties:
+      status:
+        type: string
+    type: object
+  orderitem.OrderItem:
+    properties:
+      id:
+        type: integer
+      order_id:
+        type: integer
+      product_id:
+        type: integer
+      quantity:
+        type: integer
+      unit_price:
+        type: number
+    type: object
   payment.Payment:
     properties:
       amount:
@@ -368,12 +407,139 @@ paths:
       summary: Get products by category
       tags:
       - category
-  /api/orders/{order_id}/payments:
+  /api/order:
+    post:
+      parameters:
+      - description: Provide order object
+        in: body
+        name: order
+        required: true
+        schema:
+          $ref: '#/definitions/order.Order'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/order.Order'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errdto.ErrorResponse'
+      summary: Save the order
+      tags:
+      - order
+  /api/order/{id}:
+    delete:
+      parameters:
+      - description: Order ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Hard delete
+        in: query
+        name: hard
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errdto.ErrorResponse'
+      tags:
+      - order
     get:
       parameters:
-      - description: Payment Id
+      - description: Order Id
         in: path
-        name: order_id
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/order.Order'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errdto.ErrorResponse'
+      summary: Get the order
+      tags:
+      - order
+  /api/order/{id}/status:
+    patch:
+      parameters:
+      - description: Order ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Provide order status object
+        in: body
+        name: order_status
+        required: true
+        schema:
+          $ref: '#/definitions/order.OrderStatus'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errdto.ErrorResponse'
+      summary: update order status
+      tags:
+      - order
+  /api/order/statuses:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/order.OrderStatus'
+            type: array
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errdto.ErrorResponse'
+      summary: Get list of order statuses
+      tags:
+      - order
+  /api/orders/{id}/payments:
+    get:
+      parameters:
+      - description: order Id
+        in: path
+        name: id
         required: true
         type: integer
       produces:
@@ -838,6 +1004,34 @@ paths:
       summary: Get the user
       tags:
       - user
+  /api/user/{user_id}/order:
+    get:
+      parameters:
+      - description: User Id
+        in: path
+        name: user_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/order.Order'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errdto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errdto.ErrorResponse'
+      summary: Get orders by user
+      tags:
+      - order
   /api/user/authenticate:
     post:
       parameters:

--- a/api/internal/dto/order/order_status.go
+++ b/api/internal/dto/order/order_status.go
@@ -1,0 +1,5 @@
+package order
+
+type OrderStatus struct {
+	Status string `json:"status"`
+}

--- a/api/internal/handlers/order/order_handler.go
+++ b/api/internal/handlers/order/order_handler.go
@@ -1,0 +1,183 @@
+package order
+
+import (
+	"commerce/api/internal/helpers"
+	"commerce/api/internal/services/order"
+
+	err_dto "commerce/api/internal/dto/err"
+	dto "commerce/api/internal/dto/order"
+
+	"github.com/gin-gonic/gin"
+)
+
+type OrderHandler struct {
+	svc order.OrderServiceI
+}
+
+func NewOrderHandler(svc order.OrderServiceI) *OrderHandler {
+	return &OrderHandler{svc: svc}
+}
+
+func (h *OrderHandler) RegisterRoutes(rg *gin.RouterGroup) {
+	rg.GET("/:id", h.GetById)
+	rg.GET("/statuses", h.GetStatuses)
+	rg.POST("/", h.Save)
+	rg.PATCH("/:id/status", h.UpdateStatus)
+	rg.DELETE("/:id", h.Delete)
+}
+
+// GetOrder godoc
+//
+//	@Summary	Get the order
+//	@Tags		order
+//	@Produce	json
+//	@Router		/api/order/{id} [get]
+//	@Param		id	path	int	true	"Order Id"
+//	@Success	200 {object} dto.Order
+//	@Failure	400 {object} err_dto.ErrorResponse
+//	@Failure	500 {object} err_dto.ErrorResponse
+func (h *OrderHandler) GetById(c *gin.Context) {
+	id, err := helpers.ParseParamToUint(c.Param("id"))
+	if err != nil {
+		response := err_dto.ErrorResponse{Code: 400, Message: err.Error()}
+		c.JSON(response.Code, response)
+		return
+	}
+
+	var order *dto.Order
+	order, err = h.svc.GetById(*id)
+	if err != nil {
+		response := err_dto.ErrorResponse{Code: 404, Message: err.Error()}
+		c.JSON(response.Code, response)
+		return
+	}
+	c.JSON(200, order)
+}
+
+// GetStatuses godoc
+//
+//	@Summary	Get list of order statuses
+//	@Tags		order
+//	@Produce	json
+//	@Router		/api/order/statuses [get]
+//	@Success	200 {array} dto.OrderStatus
+//	@Failure	404	{object}	err_dto.ErrorResponse
+func (h *OrderHandler) GetStatuses(c *gin.Context) {
+	var statuses []dto.OrderStatus
+	statuses = h.svc.GetStatuses()
+	c.JSON(200, statuses)
+}
+
+// UpdateStatus godoc
+//
+//	@Summary	update order status
+//	@Tags		order
+//	@Produce	json
+//	@Router		/api/order/{id}/status [patch]
+//	@Param		id		path		int		true	"Order ID"
+//	@Param   order_status  body      dto.OrderStatus  true  "Provide order status object"
+//	@Success	204
+//	@Failure	400 {object} err_dto.ErrorResponse
+//	@Failure	500 {object} err_dto.ErrorResponse
+func (h *OrderHandler) UpdateStatus(c *gin.Context) {
+	id, err := helpers.ParseParamToUint(c.Param("id"))
+	if err != nil {
+		response := err_dto.ErrorResponse{Code: 400, Message: err.Error()}
+		c.JSON(response.Code, response)
+		return
+	}
+	var status *dto.OrderStatus
+	if err := c.ShouldBindJSON(&status); err != nil {
+		errorResponse := err_dto.ErrorResponse{Code: 400, Message: err.Error()}
+		c.JSON(errorResponse.Code, errorResponse)
+		return
+	}
+	err = h.svc.UpdateStatus(*id, status.Status)
+	if err != nil {
+		errorResponse := err_dto.ErrorResponse{Code: 500, Message: err.Error()}
+		c.JSON(500, errorResponse)
+		return
+	}
+	c.JSON(204, nil)
+}
+
+// DeleteOrder godoc
+//
+//	@Summary	Delete the order
+//	@Tags		order
+//	@Produce	json
+//	@Param		id		path		int		true	"Order ID"
+//	@Param		hard	query		bool	false	"Hard delete"
+//	@Router		/api/order/{id} [delete]
+//	@Success	204
+//	@Failure	400	{object}	err_dto.ErrorResponse
+//	@Failure	500	{object}	err_dto.ErrorResponse
+func (h *OrderHandler) Delete(c *gin.Context) {
+	id, err := helpers.ParseParamToUint(c.Param("id"))
+	if err != nil {
+		errorResponse := err_dto.ErrorResponse{Code: 400, Message: err.Error()}
+		c.JSON(errorResponse.Code, errorResponse)
+		return
+	}
+	hard := c.DefaultQuery("hard", "false") == "true"
+	err = h.svc.Delete(*id, hard)
+	if err != nil {
+		errorResponse := err_dto.ErrorResponse{Code: 500, Message: err.Error()}
+		c.JSON(errorResponse.Code, errorResponse)
+		return
+	}
+	c.JSON(204, nil)
+}
+
+// Saveorder godoc
+//
+//	@Summary	Save the order
+//	@Tags		order
+//	@Produce	json
+//	@Router		/api/order [post]
+//	@Param   order  body      dto.Order  true  "Provide order object"
+//	@Success	201 {object} dto.Order
+//	@Failure	400 {object} err_dto.ErrorResponse
+//	@Failure	500 {object} err_dto.ErrorResponse
+func (h *OrderHandler) Save(c *gin.Context) {
+	var order *dto.Order
+	if err := c.ShouldBindJSON(&order); err != nil {
+		errorResponse := err_dto.ErrorResponse{Code: 400, Message: err.Error()}
+		c.JSON(errorResponse.Code, errorResponse)
+		return
+	}
+	err := h.svc.Save(*order)
+	if err != nil {
+		errorResponse := err_dto.ErrorResponse{Code: 500, Message: err.Error()}
+		c.JSON(500, errorResponse)
+		return
+	}
+	c.JSON(201, order)
+}
+
+// GetOrders godoc
+//
+//	@Summary	Get orders by user
+//	@Tags		order
+//	@Produce	json
+//	@Router		/api/user/{user_id}/order [get]
+//	@Param		user_id	path	int	true	"User Id"
+//	@Success	200 {array} dto.Order
+//	@Failure	400 {object} err_dto.ErrorResponse
+//	@Failure	500 {object} err_dto.ErrorResponse
+func (h *OrderHandler) GetByUser(c *gin.Context) {
+	userId, err := helpers.ParseParamToUint(c.Param("user_id"))
+	if err != nil {
+		response := err_dto.ErrorResponse{Code: 400, Message: err.Error()}
+		c.JSON(response.Code, response)
+		return
+	}
+	var orders []*dto.Order
+	orders, err = h.svc.GetByUserId(*userId)
+	if err != nil {
+		response := err_dto.ErrorResponse{Code: 404, Message: err.Error()}
+		c.JSON(response.Code, response)
+		return
+	}
+	c.JSON(200, orders)
+}

--- a/api/internal/handlers/payment/payment_handler.go
+++ b/api/internal/handlers/payment/payment_handler.go
@@ -58,13 +58,13 @@ func (h *PaymentHandler) GetById(c *gin.Context) {
 //	@Summary	Get payments by order
 //	@Tags		payment
 //	@Produce	json
-//	@Router		/api/orders/{order_id}/payments [get]
-//	@Param		order_id	path	int	true	"Payment Id"
+//	@Router		/api/orders/{id}/payments [get]
+//	@Param		id	path	int	true	"order Id"
 //	@Success	200 {array} dto.Payment
 //	@Failure	400 {object} err_dto.ErrorResponse
 //	@Failure	500 {object} err_dto.ErrorResponse
 func (h *PaymentHandler) GetByOrder(c *gin.Context) {
-	orderId, err := helpers.ParseParamToUint(c.Param("order_id"))
+	orderId, err := helpers.ParseParamToUint(c.Param("id"))
 	if err != nil {
 		response := err_dto.ErrorResponse{Code: 400, Message: err.Error()}
 		c.JSON(response.Code, response)

--- a/api/internal/services/order/order_service.go
+++ b/api/internal/services/order/order_service.go
@@ -12,6 +12,7 @@ import (
 type OrderServiceI interface {
 	GetById(id uint) (*dto.Order, error)
 	GetByUserId(userId uint) ([]*dto.Order, error)
+	GetStatuses() []dto.OrderStatus
 	Save(order dto.Order) error
 	Delete(id uint, hard bool) error
 	UpdateStatus(id uint, status string) error
@@ -42,6 +43,16 @@ func (o *OrderService) GetById(id uint) (*dto.Order, error) {
 		return nil, err
 	}
 	return dto.FromModel(model), nil
+}
+
+// GetStatuses implements [OrderServiceI].
+func (o *OrderService) GetStatuses() []dto.OrderStatus {
+	statuses := []dto.OrderStatus{}
+
+	for key := range validStatuses {
+		statuses = append(statuses, dto.OrderStatus{Status: string(key)})
+	}
+	return statuses
 }
 
 // GetByUserId implements [OrderServiceI].
@@ -80,13 +91,14 @@ func (o *OrderService) UpdateStatus(id uint, status string) error {
 	return o.repo.UpdateStatus(id, status)
 }
 
+var validStatuses = map[models.OrderStatus]struct{}{
+	models.OrderStatusPending:   {},
+	models.OrderStatusDelivered: {},
+	models.OrderStatusShipped:   {},
+	models.OrderStatusCancelled: {},
+}
+
 func isOrderStatusValid(status string) bool {
-	var validStatuses = map[models.OrderStatus]struct{}{
-		models.OrderStatusPending:   {},
-		models.OrderStatusDelivered: {},
-		models.OrderStatusShipped:   {},
-		models.OrderStatusCancelled: {},
-	}
 	_, ok := validStatuses[models.OrderStatus(status)]
 	return ok
 }

--- a/api/internal/services/order/order_service_test.go
+++ b/api/internal/services/order/order_service_test.go
@@ -163,3 +163,12 @@ func TestUpdateStatusRepoError(t *testing.T) {
 	err := svc.UpdateStatus(id, string(models.OrderStatusShipped))
 	assert.Error(t, err)
 }
+
+func TestGetStatuses(t *testing.T) {
+	_, svc := setup(t)
+	statuses := svc.GetStatuses()
+	assert.NotEmpty(t, statuses)
+	for i, status := range statuses {
+		t.Logf("status %d %s", i, status.Status)
+	}
+}

--- a/api/server/router/routes.go
+++ b/api/server/router/routes.go
@@ -4,6 +4,7 @@ import (
 	"commerce/api/container"
 	address_handler "commerce/api/internal/handlers/address"
 	category_handler "commerce/api/internal/handlers/category"
+	order_handler "commerce/api/internal/handlers/order"
 	payment_handler "commerce/api/internal/handlers/payment"
 	product_handler "commerce/api/internal/handlers/product"
 	review_handler "commerce/api/internal/handlers/review"
@@ -20,6 +21,7 @@ func RegisterRoutes(router *gin.Engine, c *container.Container) {
 	addressHandler := address_handler.NewAddressHandler(c.AddressService)
 	categoryHandler := category_handler.NewCategoryHandler(c.ProductService, c.CategoryService)
 	taxHandler := tax_handler.NewTaxHandler(c.TaxService)
+	orderHandler := order_handler.NewOrderHandler(c.OrderService)
 	paymentHandler := payment_handler.NewPaymentHandler(c.PaymentService)
 	productHandler := product_handler.NewProductHandler(c.ProductService)
 	userHandler := user_handler.NewUserHandler(c.UserService)
@@ -28,13 +30,15 @@ func RegisterRoutes(router *gin.Engine, c *container.Container) {
 	addressHandler.RegisterRoutes(api.Group("/address"))
 	categoryHandler.RegisterRoutes(api.Group("/category"))
 	taxHandler.RegisterRoutes(api.Group("/tax"))
+	orderHandler.RegisterRoutes(api.Group("/orders"))
 	paymentHandler.RegisterRoutes(api.Group("/payment"))
 	productHandler.RegisterRoutes(api.Group("/products"))
 	userHandler.RegisterRoutes(api.Group("/user"))
 	reviewHandler.RegisterRoutes(api.Group("/review"))
 
 	api.Group("/users/:user_id").GET("/addresses", addressHandler.GetByUserId)
-	api.Group("/orders/:order_id").GET("/payments", paymentHandler.GetByOrder)
+	api.Group("/users/:user_id").GET("/orders", orderHandler.GetByUser)
+	api.Group("/orders/:id").GET("/payments", paymentHandler.GetByOrder)
 	api.Group("/products/:id").GET("/reviews", reviewHandler.GetAllByProduct)
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swagger.Handler))
 }

--- a/docs/project-notes/issues.md
+++ b/docs/project-notes/issues.md
@@ -1,5 +1,22 @@
 # Work Log
 
+## Issue #81 — Order handler
+
+**Date:** 2026-04-09
+**Status:** Done
+**Branch:** feature/issue-81
+
+Completed `OrderHandler` and wired the nested `/users/:user_id/orders` route.
+
+- [x] `dto/order/order_status.go` — new `OrderStatus` DTO for `UpdateStatus` request body
+- [x] `order_service.go` — added `GetStatuses() []dto.OrderStatus` to `OrderServiceI` and implementation
+- [x] `order_handler.go` — `GetById`, `GetByUser`, `Save`, `Delete`, `GetStatuses`, `UpdateStatus` implemented with Swagger annotations
+- [x] `order_handler.go` — `Delete` supports `?hard=true` query param consistent with other handlers
+- [x] `routes.go` — `orderHandler.RegisterRoutes(api.Group("/orders"))` wired
+- [x] `routes.go` — nested route `GET /api/users/:user_id/orders` wired to `orderHandler.GetByUser`
+
+---
+
 ## Issue #84 — Review handler
 
 **Date:** 2026-04-08


### PR DESCRIPTION
## Summary
- Implemented `OrderHandler` with `GetById`, `GetByUser`, `Save`, `Delete`, `GetStatuses`, and `UpdateStatus` endpoints
- Added `OrderStatus` DTO and `GetStatuses()` to `OrderServiceI` to match payment handler pattern
- Wired nested route `GET /api/users/:user_id/orders` alongside existing `/users/:user_id/addresses`

## Test plan
- [x] `GET /api/orders/:id` returns an order by ID
- [x] `POST /api/orders/` creates an order with computed subtotal/tax/total
- [x] `PATCH /api/orders/:id/status` updates status; rejects invalid statuses
- [x] `DELETE /api/orders/:id` soft-deletes; `?hard=true` hard-deletes
- [x] `GET /api/orders/statuses` returns all valid order statuses
- [x] `GET /api/users/:user_id/orders` returns all orders for a user
- [x] Build passes: `cd api && go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)