### PR TITLE
feat: Dockerfile for utils migration runner

### DIFF
--- a/docker/CLAUDE.md
+++ b/docker/CLAUDE.md
@@ -50,11 +50,22 @@ COPY utils/go.mod ./utils/
 
 Only the target service's source and `internal/shared/` are copied after the dependency cache layer.
 
+## Dummy `config.json` for utils
+
+`utils/main.go` uses `//go:embed configs/config.json` — the file must exist at build time or the embed fails. Since `config.json` is gitignored, the utils Dockerfile creates a dummy after copying source:
+
+```dockerfile
+RUN echo '{}' > ./utils/configs/config.json
+```
+
+At runtime, `NewDbConfig` parses the empty JSON, fails, and falls back to env vars. See issue #105 for a potential future cleanup of this pattern.
+
 ## Dockerfile Layering Strategy
 
 1. Copy `go.work` + all `go.mod`/`go.sum` files
-2. Stub sibling modules if needed
+2. Copy sibling module `go.mod` for workspace validation
 3. `go mod download` — cached unless dependencies change
 4. Copy only the target service's source + `internal/shared/`
-5. Build the binary
-6. Runtime stage copies only the binary
+5. Create build-time workarounds (e.g. dummy `config.json` for utils)
+6. Build the binary
+7. Runtime stage copies only the binary

--- a/docker/utils/Dockerfile
+++ b/docker/utils/Dockerfile
@@ -1,0 +1,35 @@
+# Build stage
+FROM golang:1.26-alpine AS builder
+
+WORKDIR /build
+
+# Copy workspace and module files for dependency caching
+COPY go.work go.work.sum* ./
+COPY utils/go.mod utils/go.sum* ./utils/
+# api/go.mod required — go.work references ./api and go mod download
+# validates all workspace members. Only go.mod needed, not source or go.sum.
+COPY api/go.mod ./api/
+COPY internal/shared/go.mod internal/shared/go.sum ./internal/shared/
+
+RUN go mod download
+
+# Copy source — only utils and internal/shared (api source not needed)
+COPY utils/ ./utils/
+COPY internal/shared/ ./internal/shared/
+
+# config.json is gitignored — create a dummy so //go:embed succeeds.
+# At runtime, JSON parse fails and NewDbConfig falls back to env vars.
+RUN echo '{}' > ./utils/configs/config.json
+
+RUN cd utils && go build -o /app/utils .
+
+# Runtime stage
+FROM alpine:latest
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+WORKDIR /app
+COPY --from=builder /app/utils .
+
+USER appuser
+CMD ["./utils"]

--- a/docs/project-notes/issues.md
+++ b/docs/project-notes/issues.md
@@ -1,5 +1,40 @@
 # Work Log
 
+## Issue #98 — Dockerfile for utils migration runner
+
+**Date:** 2026-04-15
+**Status:** Done
+**Branch:** feature/issue-98
+
+Added `docker/utils/Dockerfile` — multi-stage build for the migration runner binary.
+
+- [x] Multi-stage build: `golang:1.26-alpine` builder → `alpine:latest` runtime
+- [x] Builder compiles from workspace root with `go.work` resolving all modules
+- [x] Sibling module `api/go.mod` copied for workspace validation (no source)
+- [x] Dummy `config.json` (`{}`) created during build so `//go:embed` succeeds — at runtime, JSON parse fails and `NewDbConfig` falls back to env vars (see #105 for future cleanup)
+- [x] Runs as non-root user (`appuser`)
+- [x] Image builds cleanly with `docker build -f docker/utils/Dockerfile .`
+
+---
+
+## Issue #97 — Dockerfile for api service
+
+**Date:** 2026-04-14 → 2026-04-15
+**Status:** Done
+**Branch:** feature/issue-97
+
+Added `docker/api/Dockerfile`, `.dockerignore`, `docker/CLAUDE.md`, and ADR-016.
+
+- [x] Multi-stage build: `golang:1.26-alpine` builder → `alpine:latest` runtime
+- [x] Sibling module `utils/go.mod` copied for workspace validation (no source)
+- [x] Runs as non-root user (`appuser`)
+- [x] `EXPOSE 8080` declared
+- [x] `.dockerignore` at workspace root
+- [x] `docker/CLAUDE.md` documenting build context, conventions, and layering strategy
+- [x] ADR-016 — centralized Docker structure with workspace-root build context
+
+---
+
 ## Issue #95 — Support env var config without dev.env file
 
 **Date:** 2026-04-13


### PR DESCRIPTION
## Summary

- Added `docker/utils/Dockerfile` — multi-stage build (`golang:1.26-alpine` → `alpine:latest`), non-root user
- Dummy `config.json` (`{}`) created at build time so `//go:embed` succeeds — at runtime, JSON parse fails and `NewDbConfig` falls back to env vars (see #105 for future cleanup)
- Updated `docker/CLAUDE.md` with the dummy config pattern and layering strategy
- Added work log entries for #97 and #98 in `docs/project-notes/issues.md`

## Build & run

```bash
# from workspace root
docker build -f docker/utils/Dockerfile .
docker run --env-file .env <image>
```

## Test plan

- [x] Image builds cleanly with `docker build -f docker/utils/Dockerfile .` from the workspace root
- [x] Container runs migrations and exits when pointed at a running Postgres instance
- [x] `GetEnvOrPanic` (via `NewDbConfig` fallback) panics correctly when required env vars are missing
- [x] Runs as non-root user (`appuser`)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)