### PR TITLE
feat: health endpoint + project notes for auth initiative

### DIFF
--- a/docs/project-notes/decisions.md
+++ b/docs/project-notes/decisions.md
@@ -507,3 +507,48 @@ DB connection values (host, port, credentials, schema) are supplied via a root `
 **Dependency ordering:** `api` uses `depends_on: utils` with `condition: service_completed_successfully` — `api` starts only after `utils` (migrations) exits with code 0. If migrations fail, `api` never starts.
 
 ---
+
+## ADR-017 — Authorization strategy (user JWT + OAuth 2.0 client credentials)
+
+**Date:** 2026-04-22
+**Status:** Proposed — tracked by issues #108 (ADR), #109 (user JWT), #110 (OAuth 2.0 client credentials)
+
+The API adopts a two-track authorization model:
+
+1. **Storefront users** → JWT bearer tokens issued by the API after email/password authentication against the existing `User` model (ADR-005 bcrypt).
+2. **Machine-to-machine clients** (partners, internal services) → OAuth 2.0 **client credentials** grant. Each client is issued a `client_id` and `client_secret`; they exchange these at `/oauth/token` for a scoped bearer token.
+
+Both tracks produce bearer tokens validated by the same Gin middleware. Every non-public route requires a valid bearer — either a user token or a client token with the required scope.
+
+### Why not full OIDC at MVP
+
+OIDC adds an identity-provider layer — useful for federation (social login, enterprise SSO) but not required for a direct-to-consumer commerce storefront. A self-contained token issuer inside the API is sufficient until federation is an actual requirement. Layering OIDC on top later does not require rewriting these two tracks.
+
+### Why both tracks (not user JWT alone)
+
+A user JWT authorizes a *browser session on behalf of a human user*. It cannot authorize a trusted backend service calling the API without a user context — e.g. a partner's order-sync job or an internal reporting worker. Client credentials is the right pattern for that case.
+
+Conversely, `client_id` + `client_secret` cannot be held by a browser (no safe way to store a secret in client-side JS). The storefront must use user JWTs, not client credentials. The two coexist; they don't overlap.
+
+### Threat-model clarification
+
+"Stop random websites from hitting the API" is not served by OAuth. Anyone with `curl` can hit any public endpoint — the control is authorizing the *request*, not the *origin*. CORS helps only against cross-origin scripts in other users' browsers; it is not a security boundary for servers. Defense here is: (a) every non-public route requires a valid bearer token, (b) rate limiting, (c) WAF at the ingress if deployed. This ADR covers (a).
+
+### Open decisions (to be resolved under #108 before implementation)
+
+- Token format — likely JWT; HS256 (symmetric) for MVP, with RS256 as a future option if third-party verification is ever needed
+- Signing key source — env var (`JWT_SIGNING_KEY`), panic on missing, consistent with existing `GetEnvOrPanic` pattern
+- Access token expiry (30 min proposed); refresh token strategy (likely deferred post-MVP)
+- Scope vocabulary for M2M clients — e.g. `orders:read`, `orders:write`, `products:read`
+- `ApiClient` model schema (`internal/shared/models/api_client.go`) — `ClientId`, bcrypt-hashed `ClientSecret`, `Scopes`, `Name`
+
+### Consequences
+
+- New `internal/shared/models/api_client.go` + repository + `AutoMigrate` registration
+- New `api/internal/handlers/auth/` (user login/register) and `api/internal/handlers/oauth/` (client-credentials token endpoint)
+- New Gin middleware extracting and validating bearer tokens, injecting claims (user id OR client id + scopes) into the request context
+- `routes.go` must classify each route: public, user-auth, or client-auth + required scope
+- New env var `JWT_SIGNING_KEY` (required — added to `.env.example` and `dev.env.example`)
+- New `utils` subcommand to register API clients — prints plaintext secret once, hashed on disk
+
+---

--- a/docs/project-notes/issues.md
+++ b/docs/project-notes/issues.md
@@ -1,5 +1,64 @@
 # Work Log
 
+## Issue #108 — ADR: authorization strategy (user JWT + OAuth 2.0 client credentials)
+
+**Date:** 2026-04-22
+**Status:** Open
+**Branch:** —
+
+Prerequisite for #109 and #110. Locks in the two-track auth model before implementation starts.
+
+- [x] ADR-017 drafted in `docs/project-notes/decisions.md` (stub — open decisions listed)
+- [ ] Token format confirmed (JWT claims, expiry, HS256 vs RS256)
+- [ ] Signing key strategy finalized (`JWT_SIGNING_KEY` via `GetEnvOrPanic`)
+- [ ] Scope vocabulary defined for M2M clients
+- [ ] Route classification matrix (public / user-auth / client-auth + required scope)
+- [ ] `MEMORY.md` ADR summary table updated with ADR-017
+
+---
+
+## Issue #109 — User authentication (JWT bearer tokens)
+
+**Date:** 2026-04-22
+**Status:** Open
+**Branch:** —
+
+JWT-based authentication for storefront users. Builds on the existing `User` model + bcrypt (ADR-005). **Blocked on #108.**
+
+- [ ] `POST /auth/login` — email + password → JWT
+- [ ] `POST /auth/register` — creates `User`, returns JWT
+- [ ] JWT issue / verify helpers
+- [ ] Gin middleware — extracts `Authorization: Bearer <token>`, validates, injects user claims into context
+- [ ] Apply middleware to user-owned routes (orders, addresses, reviews-by-user, etc.)
+- [ ] Unit tests per ADR-014
+- [ ] Swagger annotations on new endpoints
+- [ ] `JWT_SIGNING_KEY` env var loaded via `GetEnvOrPanic`; added to `dev.env.example` and root `.env.example`
+
+**Out of scope:** password reset, email verification. Refresh tokens likely deferred — decided under #108.
+
+---
+
+## Issue #110 — OAuth 2.0 client credentials (M2M authorization)
+
+**Date:** 2026-04-22
+**Status:** Open
+**Branch:** —
+
+OAuth 2.0 client-credentials grant for partner/internal-service API access. **Blocked on #108.**
+
+- [ ] `ApiClient` model in `internal/shared/models/` — `ClientId`, `ClientSecretHash` (bcrypt), `Scopes`, `Name`, embeds `Base`
+- [ ] Register `ApiClient` in `internal/shared/database/setup.go` for AutoMigrate
+- [ ] Repository (`internal/shared/repositories/api-client/`)
+- [ ] `POST /oauth/token` — `grant_type=client_credentials` → scoped access token
+- [ ] Scope-checking middleware (per-route scope requirement)
+- [ ] `utils` CLI subcommand: register a new client — prints plaintext secret once
+- [ ] Unit tests per ADR-014
+- [ ] Swagger annotations on `/oauth/token`
+
+Secret hashed bcrypt on disk (same pattern as `User.Password`); plaintext shown only at creation time via the `utils` CLI.
+
+---
+
 ## Issue #99 — docker-compose.yaml for local development
 
 **Date:** 2026-04-20

--- a/utils/internal/managers/config_manager.go
+++ b/utils/internal/managers/config_manager.go
@@ -76,3 +76,4 @@ func dbConfigFromFile(config []byte) (database.DbConfig, error) {
 
 	return cfg, nil
 }
+


### PR DESCRIPTION
## Summary

### Health check endpoint — Closes #100
- `GET /health/status/live` — returns `{"status":"UP"}` with HTTP 200
- New `api/internal/handlers/health/health_handler.go` — handler-only (no service, static response)
- Mounted at router root under `/health/status/` (outside `/api`); `/ready` and `/startup` planned alongside `/live`
- Swagger annotations added; spec regenerated

### Authorization initiative project notes — no issue closes
- **ADR-017** (Proposed) added to `docs/project-notes/decisions.md`: two-track auth — storefront user JWT + OAuth 2.0 client credentials for M2M
- Work-log entries for #108 (ADR), #109 (user JWT), #110 (OAuth 2.0 client credentials) added to `docs/project-notes/issues.md`
- `MEMORY.md` ADR summary updated (also backfills ADR-016); *Active Branch* section refreshed

Issues #108 / #109 / #110 remain open — they track implementation work, not this PR.

### Other
- Trailing newline in `utils/internal/managers/config_manager.go` (whitespace only — swept in by earlier `git add -A`)
- Stray `summary: Delete the order` in swagger files — real fix for a missing regeneration; bundled into this commit

## Test plan
- [ ] `curl http://localhost:8080/health/status/live` → `{"status":"UP"}` and HTTP 200
- [ ] Swagger UI at `/swagger/index.html` shows the new endpoint under the `Health` tag
- [ ] Existing endpoints unaffected
- [ ] Spot-check ADR-017 renders correctly on GitHub