### PR TITLE
feat(ci): ECS deploy job — migrate-gate + roll API on v* tag

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -69,3 +69,80 @@ jobs:
             -t "$REGISTRY/$REPOSITORY:$IMAGE_TAG" \
             .
           docker push "$REGISTRY/$REPOSITORY:$IMAGE_TAG"
+
+  # Roll the new images out to ECS, gated on a successful migration. Runs only
+  # after BOTH images are pushed. The task-definition family/config is owned by
+  # Terraform (iac-matrix); CI only registers a new revision with the SHA image
+  # tag swapped in — nothing about the repo URL, env, or networking is hardcoded.
+  # Requires the commerce-ci role to have ECS deploy + iam:PassRole permissions
+  # (iac-matrix aws/commerce/iam.tf — "Phase 2").
+  deploy:
+    needs: publish
+    runs-on: ubuntu-latest
+    environment: aws
+    env:
+      CLUSTER: commerce-cluster
+      IMAGE_TAG: ${{ github.sha }}
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ vars.AWS_CI_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # Migrations gate the API roll: register a utils revision with the SHA
+      # image, run it as a one-shot Fargate task, and fail the job (so the API
+      # is NOT deployed) on any non-zero exit.
+      - name: Run DB migrations (utils one-shot task — gates the API roll)
+        run: |
+          set -euo pipefail
+          aws ecs describe-task-definition --task-definition commerce-utils \
+            --query taskDefinition --output json > utils-td.json
+          jq --arg sha "$IMAGE_TAG" '
+            del(.taskDefinitionArn,.revision,.status,.requiresAttributes,.compatibilities,.registeredAt,.registeredBy)
+            | .containerDefinitions[0].image |= sub(":[^:/]+$"; ":" + $sha)
+          ' utils-td.json > utils-td-new.json
+          UTILS_REV=$(aws ecs register-task-definition --cli-input-json file://utils-td-new.json \
+            --query 'taskDefinition.revision' --output text)
+          echo "registered commerce-utils:$UTILS_REV"
+
+          # Reuse the live API service's VPC networking for the one-shot task.
+          NET=$(aws ecs describe-services --cluster "$CLUSTER" --services commerce-api \
+            --query 'services[0].networkConfiguration' --output json)
+
+          TASK=$(aws ecs run-task --cluster "$CLUSTER" \
+            --task-definition "commerce-utils:$UTILS_REV" \
+            --launch-type FARGATE \
+            --network-configuration "$NET" \
+            --query 'tasks[0].taskArn' --output text)
+          echo "migration task: $TASK"
+          aws ecs wait tasks-stopped --cluster "$CLUSTER" --tasks "$TASK"
+
+          EXIT=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK" \
+            --query 'tasks[0].containers[0].exitCode' --output text)
+          echo "migration exit code: $EXIT"
+          if [ "$EXIT" != "0" ]; then
+            echo "::error::Migration failed (exit=$EXIT) — aborting API deploy"
+            aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK" \
+              --query 'tasks[0].stoppedReason' --output text
+            exit 1
+          fi
+
+      - name: Deploy API (register revision + roll service)
+        run: |
+          set -euo pipefail
+          aws ecs describe-task-definition --task-definition commerce-api \
+            --query taskDefinition --output json > api-td.json
+          jq --arg sha "$IMAGE_TAG" '
+            del(.taskDefinitionArn,.revision,.status,.requiresAttributes,.compatibilities,.registeredAt,.registeredBy)
+            | .containerDefinitions[0].image |= sub(":[^:/]+$"; ":" + $sha)
+          ' api-td.json > api-td-new.json
+          API_REV=$(aws ecs register-task-definition --cli-input-json file://api-td-new.json \
+            --query 'taskDefinition.revision' --output text)
+          echo "registered commerce-api:$API_REV"
+
+          aws ecs update-service --cluster "$CLUSTER" --service commerce-api \
+            --task-definition "commerce-api:$API_REV" --force-new-deployment >/dev/null
+          echo "waiting for service to stabilize..."
+          aws ecs wait services-stable --cluster "$CLUSTER" --services commerce-api
+          echo "API deployed: commerce-api:$API_REV"


### PR DESCRIPTION
## What
Adds the deferred **deploy half** of the image pipeline — a `deploy` job in `publish-images.yml` that runs after both images push on a `v*` tag (`needs: publish`, `environment: aws`):

1. **Migrate (gate):** register a `commerce-utils` task-def revision with the SHA image, run it as a one-shot Fargate task, and **fail the job on non-zero exit** — a failed migration blocks the API roll (per the deploy contract in `utils/CLAUDE.md`).
2. **Deploy API:** register a `commerce-api` revision with the SHA image, `update-service --force-new-deployment`, then `wait services-stable`.

## Design
- Task-def family/config stays **Terraform-owned**; CI only swaps the image `:tag` → `github.sha` (jq, idempotent on re-deploy).
- `run-task` networking is read from the live service (`describe-services`) — **nothing hardcoded** (no registry/repo/subnet/SG literals).

## Depends on
- `iac-matrix` Phase 2 IAM (`commerce-ci` `ecs-deploy` policy: ECS deploy actions + scoped `iam:PassRole`) — **already applied** (branch `feature/issue-14`).

## Background
This was the manual sequence used to recover the stuck `commerce-api` service (task def pinned to `:latest`, which is never pushed). The first deploy (tag `v1.0.0`) was done by hand; this automates it for subsequent tags.

## Test plan
Push a new `v*` tag after merge → watch `publish` (build/push) → `deploy` (migrate-gate → roll). Migration failure should abort before the API rolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)